### PR TITLE
[BE] 댓글 기능 구현 

### DIFF
--- a/BE/src/main/java/com/squadmap/comment/application/CommentService.java
+++ b/BE/src/main/java/com/squadmap/comment/application/CommentService.java
@@ -2,110 +2,15 @@ package com.squadmap.comment.application;
 
 import com.squadmap.comment.application.dto.CommentInfo;
 import com.squadmap.comment.application.dto.CommentResponse;
-import com.squadmap.comment.domain.Comment;
-import com.squadmap.comment.infrastructure.CommentRepository;
 import com.squadmap.common.SimpleSlice;
-import com.squadmap.common.excetpion.ClientException;
-import com.squadmap.common.excetpion.ErrorStatusCodeAndMessage;
-import com.squadmap.group.infrastructure.GroupMemberRepository;
-import com.squadmap.member.domain.Member;
-import com.squadmap.member.infrastructure.MemberRepository;
-import com.squadmap.place.domain.Place;
-import com.squadmap.place.infrastructure.PlaceRepository;
-import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Slice;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
-import java.util.Map;
-import java.util.function.Function;
-import java.util.stream.Collectors;
+public interface CommentService {
 
-@Service
-@RequiredArgsConstructor
-@Transactional(readOnly = true)
-public class CommentService {
+    CommentInfo writeComment(Long memberId, Long placeId, String content);
 
-    private final CommentRepository commentRepository;
-    private final PlaceRepository placeRepository;
-    private final MemberRepository memberRepository;
-    private final GroupMemberRepository groupMemberRepository;
+    CommentResponse updateComment(Long memberId, Long commentId, String contents);
 
-    @Transactional
-    public CommentInfo writeComment(Long memberId, Long placeId, String content) {
-        Place place = placeRepository.findPlaceFetchAllById(placeId)
-                .orElseThrow(() -> new ClientException(ErrorStatusCodeAndMessage.NO_SUCH_PLACE));
+    Long deleteComment(Long memberId, Long commentId);
 
-        if(!groupMemberRepository.existsByMapIdAndMemberId(place.getMapId(), memberId)) {
-            throw new ClientException(ErrorStatusCodeAndMessage.NO_SUCH_GROUP_MEMBER);
-        }
-
-        Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> new ClientException(ErrorStatusCodeAndMessage.NO_SUCH_MEMBER));
-
-        Comment comment = commentRepository.save(new Comment(member.getId(), place, content));
-
-        return new CommentInfo(member.getId(), member.getNickname(), member.getProfileImage(),
-                comment.getId(), comment.getContent());
-    }
-
-    @Transactional
-    public CommentResponse updateComment(Long memberId, Long commentId, String contents) {
-
-        Comment comment = commentRepository.findById(commentId)
-                .orElseThrow(() -> new ClientException(ErrorStatusCodeAndMessage.NO_SUCH_COMMENT));
-
-        if(!comment.isWriterId(memberId)) {
-            throw new ClientException(ErrorStatusCodeAndMessage.FORBIDDEN);
-        }
-
-        comment.update(contents);
-        return new CommentResponse(commentId);
-
-    }
-
-    @Transactional
-    public Long deleteComment(Long memberId, Long commentId) {
-
-        Comment comment = commentRepository.findById(commentId)
-                .orElseThrow(() -> new ClientException(ErrorStatusCodeAndMessage.NO_SUCH_COMMENT));
-
-        if(!comment.isWriterId(memberId)) {
-            throw new ClientException(ErrorStatusCodeAndMessage.FORBIDDEN);
-        }
-        commentRepository.delete(comment);
-
-        return comment.getId();
-    }
-
-    public SimpleSlice<CommentInfo> readComments(Long memberId, Long placeId, Long lastCommentId, Integer size) {
-
-        Place place = placeRepository.findPlaceFetchMapById(placeId)
-                .orElseThrow(() -> new ClientException(ErrorStatusCodeAndMessage.NO_SUCH_PLACE));
-
-        if(!groupMemberRepository.existsByMapIdAndMemberId(place.getMapId(), memberId)
-                || !place.getMap().isFullDisclosure()) {
-            throw new ClientException(ErrorStatusCodeAndMessage.FORBIDDEN);
-        }
-
-        Slice<Comment> comments = commentRepository.findCommentsByPlaceIdAndIdIsAfter(placeId, lastCommentId, Pageable.ofSize(size));
-
-        List<Long> memberIds = comments.getContent().stream()
-                .map(Comment::getMemberId)
-                .collect(Collectors.toUnmodifiableList());
-
-        Map<Long, Member> memberMap = memberRepository.findAllById(memberIds)
-                .stream()
-                .collect(Collectors.toMap(Member::getId, Function.identity()));
-
-        Slice<CommentInfo> commentInfos = comments.map(comment -> {
-            Member member = memberMap.get(comment.getMemberId());
-            return new CommentInfo(member.getId(), member.getNickname(), member.getProfileImage(),
-                    comment.getId(), comment.getContent());
-        });
-
-        return new SimpleSlice<>(commentInfos);
-    }
+    SimpleSlice<CommentInfo> readComments(Long memberId, Long placeId, Long lastCommentId, Integer size);
 }

--- a/BE/src/main/java/com/squadmap/comment/application/CommentService.java
+++ b/BE/src/main/java/com/squadmap/comment/application/CommentService.java
@@ -1,8 +1,10 @@
 package com.squadmap.comment.application;
 
 import com.squadmap.comment.application.dto.CommentInfo;
+import com.squadmap.comment.application.dto.CommentResponse;
 import com.squadmap.comment.domain.Comment;
 import com.squadmap.comment.infrastructure.CommentRepository;
+import com.squadmap.common.SimpleSlice;
 import com.squadmap.common.excetpion.ClientException;
 import com.squadmap.common.excetpion.ErrorStatusCodeAndMessage;
 import com.squadmap.group.infrastructure.GroupMemberRepository;
@@ -11,8 +13,15 @@ import com.squadmap.member.infrastructure.MemberRepository;
 import com.squadmap.place.domain.Place;
 import com.squadmap.place.infrastructure.PlaceRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -40,5 +49,63 @@ public class CommentService {
 
         return new CommentInfo(member.getId(), member.getNickname(), member.getProfileImage(),
                 comment.getId(), comment.getContent());
+    }
+
+    @Transactional
+    public CommentResponse updateComment(Long memberId, Long commentId, String contents) {
+
+        Comment comment = commentRepository.findById(commentId)
+                .orElseThrow(() -> new ClientException(ErrorStatusCodeAndMessage.NO_SUCH_COMMENT));
+
+        if(!comment.isWriterId(memberId)) {
+            throw new ClientException(ErrorStatusCodeAndMessage.FORBIDDEN);
+        }
+
+        comment.update(contents);
+        return new CommentResponse(commentId);
+
+    }
+
+    @Transactional
+    public Long deleteComment(Long memberId, Long commentId) {
+
+        Comment comment = commentRepository.findById(commentId)
+                .orElseThrow(() -> new ClientException(ErrorStatusCodeAndMessage.NO_SUCH_COMMENT));
+
+        if(!comment.isWriterId(memberId)) {
+            throw new ClientException(ErrorStatusCodeAndMessage.FORBIDDEN);
+        }
+        commentRepository.delete(comment);
+
+        return comment.getId();
+    }
+
+    public SimpleSlice<CommentInfo> readComments(Long memberId, Long placeId, Long lastCommentId, Integer size) {
+
+        Place place = placeRepository.findPlaceFetchMapById(placeId)
+                .orElseThrow(() -> new ClientException(ErrorStatusCodeAndMessage.NO_SUCH_PLACE));
+
+        if(!groupMemberRepository.existsByMapIdAndMemberId(place.getMapId(), memberId)
+                || !place.getMap().isFullDisclosure()) {
+            throw new ClientException(ErrorStatusCodeAndMessage.FORBIDDEN);
+        }
+
+        Slice<Comment> comments = commentRepository.findCommentsByPlaceIdAndIdIsAfter(placeId, lastCommentId, Pageable.ofSize(size));
+
+        List<Long> memberIds = comments.getContent().stream()
+                .map(Comment::getMemberId)
+                .collect(Collectors.toUnmodifiableList());
+
+        Map<Long, Member> memberMap = memberRepository.findAllById(memberIds)
+                .stream()
+                .collect(Collectors.toMap(Member::getId, Function.identity()));
+
+        Slice<CommentInfo> commentInfos = comments.map(comment -> {
+            Member member = memberMap.get(comment.getMemberId());
+            return new CommentInfo(member.getId(), member.getNickname(), member.getProfileImage(),
+                    comment.getId(), comment.getContent());
+        });
+
+        return new SimpleSlice<>(commentInfos);
     }
 }

--- a/BE/src/main/java/com/squadmap/comment/application/CommentServiceImpl.java
+++ b/BE/src/main/java/com/squadmap/comment/application/CommentServiceImpl.java
@@ -1,0 +1,115 @@
+package com.squadmap.comment.application;
+
+import com.squadmap.comment.application.dto.CommentInfo;
+import com.squadmap.comment.application.dto.CommentResponse;
+import com.squadmap.comment.domain.Comment;
+import com.squadmap.comment.infrastructure.CommentRepository;
+import com.squadmap.common.SimpleSlice;
+import com.squadmap.common.excetpion.ClientException;
+import com.squadmap.common.excetpion.ErrorStatusCodeAndMessage;
+import com.squadmap.group.infrastructure.GroupMemberRepository;
+import com.squadmap.member.domain.Member;
+import com.squadmap.member.infrastructure.MemberRepository;
+import com.squadmap.place.domain.Place;
+import com.squadmap.place.infrastructure.PlaceRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CommentServiceImpl implements CommentService {
+
+    private final CommentRepository commentRepository;
+    private final PlaceRepository placeRepository;
+    private final MemberRepository memberRepository;
+    private final GroupMemberRepository groupMemberRepository;
+
+    @Override
+    @Transactional
+    public CommentInfo writeComment(Long memberId, Long placeId, String content) {
+        Place place = placeRepository.findPlaceFetchAllById(placeId)
+                .orElseThrow(() -> new ClientException(ErrorStatusCodeAndMessage.NO_SUCH_PLACE));
+
+        if(!groupMemberRepository.existsByMapIdAndMemberId(place.getMapId(), memberId)) {
+            throw new ClientException(ErrorStatusCodeAndMessage.NO_SUCH_GROUP_MEMBER);
+        }
+
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new ClientException(ErrorStatusCodeAndMessage.NO_SUCH_MEMBER));
+
+        Comment comment = commentRepository.save(new Comment(member.getId(), place, content));
+
+        return new CommentInfo(member.getId(), member.getNickname(), member.getProfileImage(),
+                comment.getId(), comment.getContent());
+    }
+
+    @Override
+    @Transactional
+    public CommentResponse updateComment(Long memberId, Long commentId, String contents) {
+
+        Comment comment = commentRepository.findById(commentId)
+                .orElseThrow(() -> new ClientException(ErrorStatusCodeAndMessage.NO_SUCH_COMMENT));
+
+        if(!comment.isWriterId(memberId)) {
+            throw new ClientException(ErrorStatusCodeAndMessage.FORBIDDEN);
+        }
+
+        comment.update(contents);
+        return new CommentResponse(commentId);
+
+    }
+
+    @Override
+    @Transactional
+    public Long deleteComment(Long memberId, Long commentId) {
+
+        Comment comment = commentRepository.findById(commentId)
+                .orElseThrow(() -> new ClientException(ErrorStatusCodeAndMessage.NO_SUCH_COMMENT));
+
+        if(!comment.isWriterId(memberId)) {
+            throw new ClientException(ErrorStatusCodeAndMessage.FORBIDDEN);
+        }
+        commentRepository.delete(comment);
+
+        return comment.getId();
+    }
+
+    @Override
+    public SimpleSlice<CommentInfo> readComments(Long memberId, Long placeId, Long lastCommentId, Integer size) {
+
+        Place place = placeRepository.findPlaceFetchMapById(placeId)
+                .orElseThrow(() -> new ClientException(ErrorStatusCodeAndMessage.NO_SUCH_PLACE));
+
+        if(!groupMemberRepository.existsByMapIdAndMemberId(place.getMapId(), memberId)
+                || !place.getMap().isFullDisclosure()) {
+            throw new ClientException(ErrorStatusCodeAndMessage.FORBIDDEN);
+        }
+
+        Slice<Comment> comments = commentRepository.findCommentsByPlaceIdAndIdIsAfter(placeId, lastCommentId, Pageable.ofSize(size));
+
+        List<Long> memberIds = comments.getContent().stream()
+                .map(Comment::getMemberId)
+                .collect(Collectors.toUnmodifiableList());
+
+        Map<Long, Member> memberMap = memberRepository.findAllById(memberIds)
+                .stream()
+                .collect(Collectors.toMap(Member::getId, Function.identity()));
+
+        Slice<CommentInfo> commentInfos = comments.map(comment -> {
+            Member member = memberMap.get(comment.getMemberId());
+            return new CommentInfo(member.getId(), member.getNickname(), member.getProfileImage(),
+                    comment.getId(), comment.getContent());
+        });
+
+        return new SimpleSlice<>(commentInfos);
+    }
+}

--- a/BE/src/main/java/com/squadmap/comment/application/dto/CommentInfo.java
+++ b/BE/src/main/java/com/squadmap/comment/application/dto/CommentInfo.java
@@ -11,6 +11,6 @@ public class CommentInfo {
     private final String memberNickname;
     private final String memberProfileImage;
     private final Long commentId;
-    private final String comment;
+    private final String content;
 
 }

--- a/BE/src/main/java/com/squadmap/comment/application/dto/CommentResponse.java
+++ b/BE/src/main/java/com/squadmap/comment/application/dto/CommentResponse.java
@@ -1,0 +1,11 @@
+package com.squadmap.comment.application.dto;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public class CommentResponse {
+
+    private final Long commentId;
+}

--- a/BE/src/main/java/com/squadmap/comment/domain/Comment.java
+++ b/BE/src/main/java/com/squadmap/comment/domain/Comment.java
@@ -53,8 +53,12 @@ public class Comment {
         return content;
     }
 
-    private void update(String content) {
+    public void update(String content) {
         this.content = checkContentLength(content);
+    }
+
+    public boolean isWriterId(Long memberId) {
+        return this.memberId.equals(memberId);
     }
 
 }

--- a/BE/src/main/java/com/squadmap/comment/infrastructure/CommentRepository.java
+++ b/BE/src/main/java/com/squadmap/comment/infrastructure/CommentRepository.java
@@ -1,8 +1,19 @@
 package com.squadmap.comment.infrastructure;
 
 import com.squadmap.comment.domain.Comment;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.web.bind.annotation.PathVariable;
+
+import java.util.Optional;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
 
+    @Query("select c from Comment c join fetch c.place where c.id = :commentId")
+    Optional<Comment> findByIdFetchPlace(@Param("commentId") Long commentId);
+
+    Slice<Comment> findCommentsByPlaceIdAndIdIsAfter(Long placeId, Long lastCommentId, Pageable pageable);
 }

--- a/BE/src/main/java/com/squadmap/comment/infrastructure/CommentRepository.java
+++ b/BE/src/main/java/com/squadmap/comment/infrastructure/CommentRepository.java
@@ -16,4 +16,6 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
     Optional<Comment> findByIdFetchPlace(@Param("commentId") Long commentId);
 
     Slice<Comment> findCommentsByPlaceIdAndIdIsAfter(Long placeId, Long lastCommentId, Pageable pageable);
+
+    Slice<Comment> findTop5ByPlaceId(Long placeId);
 }

--- a/BE/src/main/java/com/squadmap/comment/infrastructure/CommentRepository.java
+++ b/BE/src/main/java/com/squadmap/comment/infrastructure/CommentRepository.java
@@ -17,5 +17,5 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
 
     Slice<Comment> findCommentsByPlaceIdAndIdIsAfter(Long placeId, Long lastCommentId, Pageable pageable);
 
-    Slice<Comment> findTop5ByPlaceId(Long placeId);
+    Slice<Comment> findCommentsByPlaceId(Long placeId, Pageable pageable);
 }

--- a/BE/src/main/java/com/squadmap/comment/ui/CommentController.java
+++ b/BE/src/main/java/com/squadmap/comment/ui/CommentController.java
@@ -2,14 +2,12 @@ package com.squadmap.comment.ui;
 
 import com.squadmap.comment.application.CommentService;
 import com.squadmap.comment.application.dto.CommentInfo;
+import com.squadmap.comment.application.dto.CommentResponse;
 import com.squadmap.comment.ui.dto.CommentRequest;
+import com.squadmap.common.SimpleSlice;
 import com.squadmap.common.auth.Login;
-import com.squadmap.member.application.MemberService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
 
@@ -18,15 +16,35 @@ import javax.validation.Valid;
 public class CommentController {
 
     private final CommentService commentService;
-    private final MemberService memberService;
 
     @PostMapping("/places/{placeId}/comments")
     public CommentInfo writeComment(@Login Long memberId,
                                     @PathVariable Long placeId,
                                     @RequestBody @Valid CommentRequest commentRequest) {
 
+        return commentService.writeComment(memberId, placeId, commentRequest.getContents());
+    }
 
 
-        return null;
+    @PatchMapping("/comments/{commentId}")
+    public CommentResponse updateComment(@Login Long memberId,
+                                         @PathVariable Long commentId,
+                                         @RequestBody @Valid CommentRequest commentRequest) {
+
+        return commentService.updateComment(memberId, commentId, commentRequest.getContents());
+    }
+
+    @GetMapping("/places/{placeId}/comments")
+    public SimpleSlice<CommentInfo> readCommentsOfPlace(@Login Long memberId,
+                                           @PathVariable Long placeId,
+                                           Long lastCommentId, Integer size) {
+
+        return commentService.readComments(memberId, placeId, lastCommentId, size);
+    }
+
+    @DeleteMapping("/comments/{commentId}")
+    public CommentResponse deleteComment(@Login Long memberId, @PathVariable Long commentId) {
+
+        return new CommentResponse(commentService.deleteComment(memberId, commentId));
     }
 }

--- a/BE/src/main/java/com/squadmap/comment/ui/CommentController.java
+++ b/BE/src/main/java/com/squadmap/comment/ui/CommentController.java
@@ -7,6 +7,7 @@ import com.squadmap.comment.ui.dto.CommentRequest;
 import com.squadmap.common.SimpleSlice;
 import com.squadmap.common.auth.Login;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
@@ -18,11 +19,12 @@ public class CommentController {
     private final CommentService commentService;
 
     @PostMapping("/places/{placeId}/comments")
+    @ResponseStatus(HttpStatus.CREATED)
     public CommentInfo writeComment(@Login Long memberId,
                                     @PathVariable Long placeId,
                                     @RequestBody @Valid CommentRequest commentRequest) {
 
-        return commentService.writeComment(memberId, placeId, commentRequest.getContents());
+        return commentService.writeComment(memberId, placeId, commentRequest.getContent());
     }
 
 
@@ -31,7 +33,7 @@ public class CommentController {
                                          @PathVariable Long commentId,
                                          @RequestBody @Valid CommentRequest commentRequest) {
 
-        return commentService.updateComment(memberId, commentId, commentRequest.getContents());
+        return commentService.updateComment(memberId, commentId, commentRequest.getContent());
     }
 
     @GetMapping("/places/{placeId}/comments")

--- a/BE/src/main/java/com/squadmap/comment/ui/dto/CommentRequest.java
+++ b/BE/src/main/java/com/squadmap/comment/ui/dto/CommentRequest.java
@@ -15,6 +15,6 @@ public class CommentRequest {
 
     @NotBlank
     @Size(min = 1, max = 150)
-    private String contents;
+    private String content;
 
 }

--- a/BE/src/main/java/com/squadmap/common/SimpleSlice.java
+++ b/BE/src/main/java/com/squadmap/common/SimpleSlice.java
@@ -1,6 +1,6 @@
 package com.squadmap.common;
 
-import lombok.Getter;
+import com.fasterxml.jackson.annotation.JsonGetter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Slice;
 
@@ -32,7 +32,7 @@ public class SimpleSlice<T> {
     public int getNumberOfElements() {
         return numberOfElements;
     }
-
+    @JsonGetter
     public boolean hasNext() {
         return hasNext;
     }

--- a/BE/src/main/java/com/squadmap/common/SimpleSlice.java
+++ b/BE/src/main/java/com/squadmap/common/SimpleSlice.java
@@ -1,0 +1,39 @@
+package com.squadmap.common;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Slice;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+public class SimpleSlice<T> {
+
+    private final List<T> content;
+    private final int size;
+    private final int numberOfElements;
+    private final boolean hasNext;
+
+    public SimpleSlice (Slice<T> slice) {
+       this.content = slice.getContent();
+       this.size = slice.getSize();
+       this.numberOfElements = slice.getNumberOfElements();
+       this.hasNext = slice.hasNext();
+    }
+
+    public List<T> getContent() {
+        return content;
+    }
+
+    public int getSize() {
+        return size;
+    }
+
+    public int getNumberOfElements() {
+        return numberOfElements;
+    }
+
+    public boolean HasNext() {
+        return hasNext;
+    }
+}

--- a/BE/src/main/java/com/squadmap/common/SimpleSlice.java
+++ b/BE/src/main/java/com/squadmap/common/SimpleSlice.java
@@ -33,7 +33,7 @@ public class SimpleSlice<T> {
         return numberOfElements;
     }
 
-    public boolean HasNext() {
+    public boolean hasNext() {
         return hasNext;
     }
 }

--- a/BE/src/main/java/com/squadmap/common/excetpion/ErrorStatusCodeAndMessage.java
+++ b/BE/src/main/java/com/squadmap/common/excetpion/ErrorStatusCodeAndMessage.java
@@ -22,7 +22,8 @@ public enum ErrorStatusCodeAndMessage {
     REQUIRE_MAINTAIN_PERMISSION(HttpStatus.FORBIDDEN, "지도에 MAINTAIN 이상의 권한이 필요합니다."),
     OUT_OF_LIMIT_COMMENT_LENGTH(HttpStatus.BAD_REQUEST, "댓글은 1~150자 이내로만 작성할 수 있습니다."),
     NAVER_LOGIN_ERROR(HttpStatus.BAD_REQUEST, "NAVER 로그인에 실패하였습니다."),
-    GITHUB_LOGIN_ERROR(HttpStatus.BAD_REQUEST, "GITHUB 로그인에 실패하였습니다.");
+    GITHUB_LOGIN_ERROR(HttpStatus.BAD_REQUEST, "GITHUB 로그인에 실패하였습니다."),
+    NO_SUCH_COMMENT(HttpStatus.NO_CONTENT, "등록된 댓글이 없습니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/BE/src/main/java/com/squadmap/place/application/PlaceServiceImpl.java
+++ b/BE/src/main/java/com/squadmap/place/application/PlaceServiceImpl.java
@@ -2,6 +2,10 @@ package com.squadmap.place.application;
 
 import com.squadmap.category.domain.Category;
 import com.squadmap.category.infrastructure.CategoryRepository;
+import com.squadmap.comment.application.dto.CommentInfo;
+import com.squadmap.comment.domain.Comment;
+import com.squadmap.comment.infrastructure.CommentRepository;
+import com.squadmap.common.SimpleSlice;
 import com.squadmap.common.excetpion.ClientException;
 import com.squadmap.common.excetpion.ErrorStatusCodeAndMessage;
 import com.squadmap.group.domain.GroupMember;
@@ -9,15 +13,20 @@ import com.squadmap.group.domain.PermissionLevel;
 import com.squadmap.group.infrastructure.GroupMemberRepository;
 import com.squadmap.map.domain.Map;
 import com.squadmap.map.infrastructure.MapRepository;
+import com.squadmap.member.domain.Member;
+import com.squadmap.member.infrastructure.MemberRepository;
 import com.squadmap.place.application.dto.PlaceDetailInfo;
 import com.squadmap.place.domain.Place;
 import com.squadmap.place.domain.Position;
 import com.squadmap.place.infrastructure.PlaceRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.NoSuchElementException;
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -28,6 +37,8 @@ public class PlaceServiceImpl implements PlaceService {
     private final MapRepository mapRepository;
     private final CategoryRepository categoryRepository;
     private final GroupMemberRepository groupMemberRepository;
+    private final CommentRepository commentRepository;
+    private final MemberRepository memberRepository;
 
     @Override
     @Transactional
@@ -88,7 +99,23 @@ public class PlaceServiceImpl implements PlaceService {
             throw new ClientException(ErrorStatusCodeAndMessage.NO_SUCH_GROUP_MEMBER);
         };
 
-        return PlaceDetailInfo.from(place);
+        Slice<Comment> comments = commentRepository.findTop5ByPlaceId(placeId);
+        List<Long> writerIds = comments.getContent()
+                .stream()
+                .map(Comment::getMemberId)
+                .collect(Collectors.toUnmodifiableList());
+
+        java.util.Map<Long, Member> memberMap = memberRepository.findAllById(writerIds)
+                .stream()
+                .collect(Collectors.toMap(Member::getId, Function.identity()));
+
+        Slice<CommentInfo> commentInfos = comments.map(comment -> {
+            Member writer = memberMap.get(comment.getMemberId());
+            return new CommentInfo(writer.getId(), writer.getNickname(), writer.getProfileImage(),
+                    comment.getId(), comment.getContent());
+        });
+
+        return PlaceDetailInfo.of(place, new SimpleSlice<>(commentInfos));
     }
 
 

--- a/BE/src/main/java/com/squadmap/place/application/PlaceServiceImpl.java
+++ b/BE/src/main/java/com/squadmap/place/application/PlaceServiceImpl.java
@@ -20,6 +20,7 @@ import com.squadmap.place.domain.Place;
 import com.squadmap.place.domain.Position;
 import com.squadmap.place.infrastructure.PlaceRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -99,7 +100,7 @@ public class PlaceServiceImpl implements PlaceService {
             throw new ClientException(ErrorStatusCodeAndMessage.NO_SUCH_GROUP_MEMBER);
         };
 
-        Slice<Comment> comments = commentRepository.findTop5ByPlaceId(placeId);
+        Slice<Comment> comments = commentRepository.findCommentsByPlaceId(placeId, Pageable.ofSize(5));
         List<Long> writerIds = comments.getContent()
                 .stream()
                 .map(Comment::getMemberId)

--- a/BE/src/main/java/com/squadmap/place/application/dto/PlaceDetailInfo.java
+++ b/BE/src/main/java/com/squadmap/place/application/dto/PlaceDetailInfo.java
@@ -1,5 +1,7 @@
 package com.squadmap.place.application.dto;
 
+import com.squadmap.comment.application.dto.CommentInfo;
+import com.squadmap.common.SimpleSlice;
 import com.squadmap.place.domain.Place;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -16,7 +18,21 @@ public class PlaceDetailInfo {
     private final String story;
     private final String detailLink;
     private final Long categoryId;
+    private final SimpleSlice<CommentInfo> comments;
 
+    public static PlaceDetailInfo of(final Place place, final SimpleSlice<CommentInfo> comments) {
+        return new PlaceDetailInfo(
+                place.getId(),
+                place.getName(),
+                place.getAddress(),
+                place.getPosition().getLatitude(),
+                place.getPosition().getLongitude(),
+                place.getDescription(),
+                place.getDetailLink(),
+                place.getCategory().getId(),
+                comments
+        );
+    }
     public static PlaceDetailInfo from(final Place place) {
         return new PlaceDetailInfo(
                 place.getId(),
@@ -26,6 +42,9 @@ public class PlaceDetailInfo {
                 place.getPosition().getLongitude(),
                 place.getDescription(),
                 place.getDetailLink(),
-                place.getCategory().getId());
+                place.getCategory().getId(),
+                null
+        );
     }
+
 }

--- a/BE/src/main/java/com/squadmap/place/infrastructure/PlaceRepository.java
+++ b/BE/src/main/java/com/squadmap/place/infrastructure/PlaceRepository.java
@@ -20,6 +20,6 @@ public interface PlaceRepository extends JpaRepository<Place, Long> {
     @Query("select p from Place p join fetch p.map join fetch p.category where p.id = :placeId")
     Optional<Place> findPlaceFetchAllById(@Param("placeId") Long placeId);
 
-    @Query("select p from Place p join fetch p.category where p.id = :placeId")
-    Optional<Place> findPlaceFetchCategoryById(@Param("placeId") Long placeId);
+    @Query("select p from Place p join fetch p.map where p.id = :placeId")
+    Optional<Place> findPlaceFetchMapById(@Param("placeId") Long placeId);
 }

--- a/BE/src/test/java/com/squadmap/assured/RestAssuredTest.java
+++ b/BE/src/test/java/com/squadmap/assured/RestAssuredTest.java
@@ -2,7 +2,6 @@ package com.squadmap.assured;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
-import com.squadmap.DbConfigurator;
 import com.squadmap.IsolationTestExecutionListener;
 import com.squadmap.common.auth.application.JwtProvider;
 import io.restassured.RestAssured;

--- a/BE/src/test/java/com/squadmap/comment/acceptance/CommentAcceptanceTest.java
+++ b/BE/src/test/java/com/squadmap/comment/acceptance/CommentAcceptanceTest.java
@@ -1,0 +1,172 @@
+package com.squadmap.comment.acceptance;
+
+import com.squadmap.assured.RestAssuredTest;
+import com.squadmap.comment.ui.dto.CommentRequest;
+import io.restassured.http.ContentType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.restdocs.snippet.Snippet;
+
+
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.restdocs.request.RequestDocumentation.*;
+import static org.springframework.restdocs.restassured3.RestAssuredRestDocumentation.document;
+
+public class CommentAcceptanceTest extends RestAssuredTest {
+
+    private static final Snippet COMMENT_READ_REQUEST_PATH = pathParameters(
+            parameterWithName("place_id").description("장소의 아이디")
+    );
+
+    private static final Snippet COMMENT_REQUEST_FIELDS = requestFields(
+            fieldWithPath("content").type(JsonFieldType.STRING).description("작성 댓글")
+    );
+
+    private static final Snippet CREATE_COMMENT_RESPONSE_FIELDS = responseFields(
+            fieldWithPath("member_id").type(JsonFieldType.NUMBER).description("댓글 작성자 아이디"),
+            fieldWithPath("member_nickname").type(JsonFieldType.STRING).description("댓글 작성자 닉네임"),
+            fieldWithPath("member_profile_image").type(JsonFieldType.STRING).description("댓글 작성자 프로필 이미지 URL"),
+            fieldWithPath("comment_id").type(JsonFieldType.NUMBER).description("댓글 아이디"),
+            fieldWithPath("content").type(JsonFieldType.STRING).description("작성 댓글")
+    );
+
+    @Test
+    @DisplayName("지도에 Read 권한 이상의 사용자는 장소에 댓글을 작성할 수 있으며, 성공하면 상태코드 201을 반환한다.")
+    void createTest() {
+        Long memberId = 1L;
+        Long placeId = 1L;
+
+        CommentRequest commentRequest = new CommentRequest("Hi, I love it");
+        given(this.specification)
+                .filter(document(DEFAULT_RESTDOC_PATH, AUTHORIZATION_HEADER,
+                        COMMENT_READ_REQUEST_PATH, COMMENT_REQUEST_FIELDS, CREATE_COMMENT_RESPONSE_FIELDS))
+                .accept(ContentType.JSON)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .header(HttpHeaders.AUTHORIZATION, this.createAuthorizationHeader(memberId))
+                .pathParam("place_id", placeId)
+                .body(commentRequest)
+                .log().all()
+
+        .when().post("/places/{place_id}/comments", placeId)
+
+        .then().statusCode(HttpStatus.CREATED.value())
+                .log().all();
+    }
+
+    private static final Snippet COMMENT_UPDATE_REQUEST_PATH = pathParameters(
+            parameterWithName("comment_id").description("수정하고자 하는 댓글의 아이디")
+    );
+
+    private static final Snippet COMMENT_UPDATE_RESPONSE_FIELD = responseFields(
+        fieldWithPath("comment_id").type(JsonFieldType.NUMBER).description("수정된 댓글의 아이디")
+    );
+
+    @Test
+    @DisplayName("댓글 작성자는 댓글을 수정할 수 있으며, 성공하면 상태코드 200을 반환한다.")
+    void updateTest() {
+
+        Long memberId = 1L;
+        Long commentId = 1L;
+
+        CommentRequest commentRequest = new CommentRequest("Hi, I love it");
+
+        given(this.specification)
+                .filter(document(DEFAULT_RESTDOC_PATH, AUTHORIZATION_HEADER,
+                        COMMENT_UPDATE_REQUEST_PATH, COMMENT_REQUEST_FIELDS, COMMENT_UPDATE_RESPONSE_FIELD))
+                .accept(ContentType.JSON)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .header(HttpHeaders.AUTHORIZATION, this.createAuthorizationHeader(memberId))
+                .pathParam("comment_id", commentId)
+                .body(commentRequest)
+                .log().all()
+
+        .when().patch("/comments/{comment_id}", commentId)
+
+        .then().statusCode(HttpStatus.OK.value())
+                .body("comment_id", equalTo(commentId.intValue()))
+                .log().all();
+
+    }
+
+    private static final Snippet READ_PAGING_NEXT_COMMENTS_READ_QUERY_PARAMS = requestParameters(
+            parameterWithName("lastCommentId").description("마지막으로 표시된 댓글의 아이디"),
+            parameterWithName("size").description("요청하고자하는 댓글의 갯수")
+    );
+
+    private static final Snippet READ_PAGING_COMMENTS_RESPONSE_FIELDS = responseFields(
+            fieldWithPath("size").type(JsonFieldType.NUMBER).description("요청한 댓글의 갯수"),
+            fieldWithPath("number_of_elements").type(JsonFieldType.NUMBER).description("실제 반환하는 댓글의 갯수"),
+            fieldWithPath("has_next").type(JsonFieldType.BOOLEAN).description("아직 보여지지 않은 댓글들의 존재 여부"),
+            fieldWithPath("content[].member_id").type(JsonFieldType.NUMBER).description("댓글 작성자 아이디"),
+            fieldWithPath("content[].member_nickname").type(JsonFieldType.STRING).description("댓글 작성자 닉네임"),
+            fieldWithPath("content[].member_profile_image").type(JsonFieldType.STRING).description("댓글 작성자 프로필 이미지 URL"),
+            fieldWithPath("content[].comment_id").type(JsonFieldType.NUMBER).description("댓글 아이디"),
+            fieldWithPath("content[].content").type(JsonFieldType.STRING).description("작성 댓글")
+
+    );
+
+    @Test
+    @DisplayName("지도에 Read 권한 이상의 사용자 또는 PUBLIC 지도의 경우, 마지막 댓글의 아이디를 기준으로 이 후의 댓글들을 요청할 수 있으며, 성공하면 상태코드 200을 반환한다.")
+    void nextCommentReadTest() {
+
+        Long memberId = 1L;
+        Long placeId = 1L;
+        Long lastCommentId = 1L;
+        Integer requestSize = 5;
+
+        given(this.specification)
+                .filter(document(DEFAULT_RESTDOC_PATH, AUTHORIZATION_HEADER,
+                        COMMENT_READ_REQUEST_PATH, READ_PAGING_NEXT_COMMENTS_READ_QUERY_PARAMS, READ_PAGING_COMMENTS_RESPONSE_FIELDS))
+                .accept(ContentType.JSON)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .header(HttpHeaders.AUTHORIZATION, this.createAuthorizationHeader(memberId))
+                .pathParam("place_id", placeId)
+                .queryParam("lastCommentId", lastCommentId)
+                .queryParam("size", requestSize)
+                .log().all()
+
+        .when().get("/places/{place_id}/comments", placeId)
+
+        .then().statusCode(HttpStatus.OK.value())
+                .log().all();
+
+    }
+
+    private static final Snippet COMMENT_DELETE_REQUEST_PATH = pathParameters(
+            parameterWithName("comment_id").description("삭제하고자하는 댓글의 아이디")
+    );
+
+    private static final Snippet COMMENT_DELETE_RESPONSE_FIELD = responseFields(
+            fieldWithPath("comment_id").type(JsonFieldType.NUMBER).description("삭제된 댓글의 아이디")
+    );
+
+    @Test
+    @DisplayName("댓글 작성자는 자신이 작성한 댓글을 삭제할 수 있으며, 성공하면 상태코드 200을 반환한다.")
+    void deleteCommentTest() {
+
+        Long memberId = 1L;
+        Long commentId = 1L;
+
+        given(this.specification)
+                .filter(document(DEFAULT_RESTDOC_PATH, AUTHORIZATION_HEADER,
+                        COMMENT_DELETE_REQUEST_PATH, COMMENT_DELETE_RESPONSE_FIELD))
+                .accept(ContentType.JSON)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .header(HttpHeaders.AUTHORIZATION, this.createAuthorizationHeader(memberId))
+                .pathParam("comment_id", commentId)
+                .log().all()
+
+        .when().delete("/comments/{comment_id}", commentId)
+
+        .then().statusCode(HttpStatus.OK.value())
+                .log().all();
+    }
+
+}

--- a/BE/src/test/java/com/squadmap/comment/domain/CommentTest.java
+++ b/BE/src/test/java/com/squadmap/comment/domain/CommentTest.java
@@ -1,0 +1,37 @@
+package com.squadmap.comment.domain;
+
+import com.squadmap.category.domain.Category;
+import com.squadmap.common.excetpion.ClientException;
+import com.squadmap.common.excetpion.ErrorStatusCodeAndMessage;
+import com.squadmap.map.domain.Map;
+import com.squadmap.place.domain.Place;
+import com.squadmap.place.domain.Position;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.*;
+
+class CommentTest {
+
+    @Test
+    @DisplayName("Comment의 content의 길이가 150자를 초과하면 Exception이 발생한다.")
+    void CommentCreateTest() {
+
+        Long memberId = 1L;
+        String content = "a";
+        String outOfSizeContent = content.repeat(151);
+
+        String placeName = "name";
+        String address = "address";
+        Position position = new Position(123.00, 36.00);
+        String description = "description";
+        String detailLink = "detailLink";
+        Map map = Map.of("name", "emoji", true, memberId);
+        Category category = Category.of("name", "color", map);
+        Place place = Place.of(placeName, address, position, description, detailLink, map, category, memberId);
+
+        assertThatThrownBy(() -> new Comment(memberId, place, outOfSizeContent))
+                .isInstanceOf(ClientException.class)
+                .hasMessage(ErrorStatusCodeAndMessage.OUT_OF_LIMIT_COMMENT_LENGTH.getMessage());
+    }
+}

--- a/BE/src/test/java/com/squadmap/comment/integration/CommentServiceTest.java
+++ b/BE/src/test/java/com/squadmap/comment/integration/CommentServiceTest.java
@@ -1,7 +1,7 @@
 package com.squadmap.comment.integration;
 
 import com.squadmap.IntegrationTest;
-import com.squadmap.comment.application.CommentService;
+import com.squadmap.comment.application.CommentServiceImpl;
 import com.squadmap.comment.application.dto.CommentInfo;
 import com.squadmap.comment.application.dto.CommentResponse;
 import com.squadmap.comment.domain.Comment;
@@ -13,15 +13,13 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import java.util.Optional;
-
 import static org.assertj.core.api.Assertions.*;
 
 @IntegrationTest
 class CommentServiceTest {
 
     @Autowired
-    private CommentService commentService;
+    private CommentServiceImpl commentService;
 
     @Autowired
     private CommentRepository commentRepository;
@@ -39,7 +37,7 @@ class CommentServiceTest {
     }
 
     @Test
-    @DisplayName("존재하는 멤버와 장소라면, 해당 장소에 대한 댓글을 작성할 수 있다.")
+    @DisplayName("댓글의 작성자는 댓글을 수정할 수 있다.")
     void updateCommentTest() {
         Long memberId = 1L;
         Long commentId = 1L;

--- a/BE/src/test/java/com/squadmap/comment/integration/CommentServiceTest.java
+++ b/BE/src/test/java/com/squadmap/comment/integration/CommentServiceTest.java
@@ -3,11 +3,19 @@ package com.squadmap.comment.integration;
 import com.squadmap.IntegrationTest;
 import com.squadmap.comment.application.CommentService;
 import com.squadmap.comment.application.dto.CommentInfo;
+import com.squadmap.comment.application.dto.CommentResponse;
+import com.squadmap.comment.domain.Comment;
+import com.squadmap.comment.infrastructure.CommentRepository;
+import com.squadmap.common.SimpleSlice;
+import com.squadmap.common.excetpion.ClientException;
+import com.squadmap.common.excetpion.ErrorStatusCodeAndMessage;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
 
 @IntegrationTest
 class CommentServiceTest {
@@ -15,16 +23,75 @@ class CommentServiceTest {
     @Autowired
     private CommentService commentService;
 
+    @Autowired
+    private CommentRepository commentRepository;
 
     @Test
     @DisplayName("존재하는 멤버와 장소라면, 해당 장소에 대한 댓글을 작성할 수 있다.")
     void writeCommentTest() {
         Long memberId = 1L;
         Long placeId = 1L;
-        String comment = "댓글";
+        String content = "댓글";
 
-        CommentInfo commentInfo = commentService.writeComment(memberId, placeId, comment);
+        CommentInfo commentInfo = commentService.writeComment(memberId, placeId, content);
 
         assertThat(commentInfo.getCommentId()).isPositive();
     }
+
+    @Test
+    @DisplayName("존재하는 멤버와 장소라면, 해당 장소에 대한 댓글을 작성할 수 있다.")
+    void updateCommentTest() {
+        Long memberId = 1L;
+        Long commentId = 1L;
+        String content = "수정된 댓글";
+
+        CommentResponse commentResponse = commentService.updateComment(memberId, commentId, content);
+
+        Comment comment = commentRepository.findById(commentId).get();
+
+        assertThat(commentResponse.getCommentId()).isEqualTo(commentId);
+        assertThat(comment.getContent()).isEqualTo(content);
+
+    }
+
+    @Test
+    @DisplayName("지도를 읽을 수 있는 사용자라면, 선택 댓글 이후의 댓글들을 조회할 수 있다.")
+    void readCommentTest() {
+        Long memberId = 1L;
+        Long placeId = 1L;
+        Long lastCommentId = 1L;
+        Integer size = 5;
+
+        SimpleSlice<CommentInfo> comments = commentService.readComments(memberId, placeId, lastCommentId, size);
+
+        assertThat(comments.getNumberOfElements()).isEqualTo(2);
+        assertThat(comments.getSize()).isEqualTo(size);
+        assertThat(comments.hasNext()).isFalse();
+    }
+
+    @Test
+    @DisplayName("댓글의 작성자는 댓글을 삭제할 수 있다.")
+    void deleteCommentTest() {
+        Long memberId = 1L;
+        Long commentId = 1L;
+
+        Long deletedCommentId = commentService.deleteComment(memberId, commentId);
+
+        assertThat(deletedCommentId).isEqualTo(commentId);
+        assertThat(commentRepository.findById(commentId).isEmpty()).isTrue();
+    }
+
+    @Test
+    @DisplayName("댓글의 작성자가 아닌 사용자가 댓글을 삭제하려하면, ClientException이 발생한다.")
+    void deleteCommentTest_not_writer_error() {
+        Long memberId = 3L;
+        Long commentId = 1L;
+
+        assertThatThrownBy(() -> commentService.deleteComment(memberId, commentId))
+                .isInstanceOf(ClientException.class)
+                .hasMessage(ErrorStatusCodeAndMessage.FORBIDDEN.getMessage());
+    }
+
+
+
 }

--- a/BE/src/test/java/com/squadmap/place/acceptance/PlaceAcceptanceTest.java
+++ b/BE/src/test/java/com/squadmap/place/acceptance/PlaceAcceptanceTest.java
@@ -12,6 +12,8 @@ import org.springframework.http.MediaType;
 import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.restdocs.snippet.Snippet;
 
+import java.util.List;
+
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.notNullValue;
@@ -50,13 +52,14 @@ class PlaceAcceptanceTest extends RestAssuredTest {
         String detailLink = "https://kakaomap";
         Long mapId = 1L;
         Long categoryId = 1L;
-        String tokenHeader = "Bearer " + jwtProvider.generateAccessToken(1L);
+        Long memberId = 1L;
+
         PlaceRequest placeRequest = new PlaceRequest(placeName, address, x, y, story, detailLink, mapId, categoryId);
 
         given(this.specification).filter(document(DEFAULT_RESTDOC_PATH, CREATE_REQUEST_FIELDS, CREATE_RESPONSE_FIELDS, AUTHORIZATION_HEADER))
                 .accept(ContentType.JSON)
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .header(HttpHeaders.AUTHORIZATION, tokenHeader)
+                .header(HttpHeaders.AUTHORIZATION, this.createAuthorizationHeader(memberId))
                 .body(placeRequest)
                 .log().all()
 
@@ -122,7 +125,15 @@ class PlaceAcceptanceTest extends RestAssuredTest {
             fieldWithPath("longitude").type(JsonFieldType.NUMBER).description("장소 경도"),
             fieldWithPath("story").type(JsonFieldType.STRING).description("장소 설명"),
             fieldWithPath("detail_link").type(JsonFieldType.STRING).description("장소에 대한 링크"),
-            fieldWithPath("category_id").type(JsonFieldType.NUMBER).description("카테고리의 아이디")
+            fieldWithPath("category_id").type(JsonFieldType.NUMBER).description("카테고리의 아이디"),
+            fieldWithPath("comments.content[].member_id").type(JsonFieldType.NUMBER).description("댓글 작성자 아이디"),
+            fieldWithPath("comments.content[].member_nickname").type(JsonFieldType.STRING).description("댓글 작성자 닉네임"),
+            fieldWithPath("comments.content[].member_profile_image").type(JsonFieldType.STRING).description("댓글 작성자 프로필 이미지"),
+            fieldWithPath("comments.content[].comment_id").type(JsonFieldType.NUMBER).description("댓글 아이디"),
+            fieldWithPath("comments.content[].comment").type(JsonFieldType.STRING).description("댓글 내용"),
+            fieldWithPath("comments.size").type(JsonFieldType.NUMBER).description("default size 5, (최초 장소 조회시 5개까지의 댓글만을 조회)"),
+            fieldWithPath("comments.number_of_elements").type(JsonFieldType.NUMBER).description("실제 조회된 댓글의 갯수"),
+            fieldWithPath("comments.has_next").type(JsonFieldType.BOOLEAN).description("보여진 댓글보다 많은 댓글이 존재하는지에 대한 여부")
     );
 
     @Test

--- a/BE/src/test/resources/application-test.yml
+++ b/BE/src/test/resources/application-test.yml
@@ -16,7 +16,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
 
     database-platform: org.hibernate.dialect.MySQL8Dialect
 

--- a/BE/src/test/resources/data-script.sql
+++ b/BE/src/test/resources/data-script.sql
@@ -10,3 +10,7 @@ insert into `member` (nickname, profile_image, email, resource_server) values ('
 insert into `group_member` (map_id, member_id, permission_level) values (1, 1, 'HOST');
 insert into `group_member` (map_id, member_id, permission_level) values (1, 2, 'MAINTAIN');
 insert into `group_member` (map_id, member_id, permission_level) values (1, 3, 'MAINTAIN');
+insert into `comment` (member_id, place_id, content, written_at, modified_at) values (1, 1, "It's Good", NOW(), NOW());
+insert into `comment` (member_id, place_id, content, written_at, modified_at) values (2, 1, "It's my favorite place", NOW(), NOW());
+insert into `comment` (member_id, place_id, content, written_at, modified_at) values (3, 1, "umm... so so", NOW(), NOW());
+


### PR DESCRIPTION
## PR 내용

### 1. 댓글 작성
- 지도 내 등록된 장소마다 지도의 그룹 멤버(`READ`) 권한 이상의 사용자는 댓글을 작성할 수 있음.

### 2. 댓글 수정/삭제
- 댓글의 작성자만이 댓글을 수정, 삭제할 수 있음

### 3. 댓글 조회
- 무한 스크롤로 댓글을 계속 볼 수 있도록 구현하고자 no-offset과 Slice 자료구조를 통해서 구현하였음.

### 4. 장소 디테일 조회 반환 데이터 추가
- 기존 장소 디테일 조회 시 댓글을 상위 5개를 같이 리턴하도록 API 바디를 수정하였음

##### TODO
- 전체적인 패키지 구조 리팩토링
- 지도 접근과 관련한 권한에 대해서 AOP 적용을 통해서 중복된 코드를 리팩토링
- 미비한 테스트들 추가 및 체크하기