### PR TITLE
[BE] HOST 권한 변경 오류 및 그룹 지도 조회시 잘못된 지도 정보 응답 오류 수정 

### DIFF
--- a/BE/src/main/java/com/squadmap/core/group/domain/GroupMember.java
+++ b/BE/src/main/java/com/squadmap/core/group/domain/GroupMember.java
@@ -34,6 +34,7 @@ public class GroupMember {
     }
 
     public void updatePermissionLevel(String level) {
+        this.permissionLevel.checkChangeable();
         PermissionLevel permissionLevel = PermissionLevel.valueOf(level);
         if (permissionLevel.equals(PermissionLevel.HOST)) {
             throw new ClientException(ErrorStatusCodeAndMessage.UNIQUE_HOST);

--- a/BE/src/main/java/com/squadmap/core/group/domain/PermissionLevel.java
+++ b/BE/src/main/java/com/squadmap/core/group/domain/PermissionLevel.java
@@ -1,7 +1,17 @@
 package com.squadmap.core.group.domain;
 
+import com.squadmap.common.excetpion.ClientException;
+import com.squadmap.common.excetpion.ErrorStatusCodeAndMessage;
+
 public enum PermissionLevel {
 
     HOST, MAINTAIN, READ;
+
+
+    public void checkChangeable() {
+        if (this.equals(PermissionLevel.HOST)) {
+            throw new ClientException(ErrorStatusCodeAndMessage.HOST_IMMUTABLE);
+        }
+    }
 
 }

--- a/BE/src/main/java/com/squadmap/core/group/infrastructure/GroupMemberRepository.java
+++ b/BE/src/main/java/com/squadmap/core/group/infrastructure/GroupMemberRepository.java
@@ -19,7 +19,7 @@ public interface GroupMemberRepository extends JpaRepository<GroupMember, Long> 
 
     boolean existsByMapIdAndMemberId(Long mapId, Long memberId);
 
-    @Query("select gm.id from GroupMember gm where gm.memberId = :memberId")
+    @Query("select gm.mapId from GroupMember gm where gm.memberId = :memberId")
     List<Long> findMapIdByMemberId(@Param("memberId") Long memberId);
 
     @Modifying

--- a/BE/src/test/java/com/squadmap/group/domain/GroupMemberTest.java
+++ b/BE/src/test/java/com/squadmap/group/domain/GroupMemberTest.java
@@ -1,0 +1,81 @@
+package com.squadmap.group.domain;
+
+import com.squadmap.common.excetpion.ClientException;
+import com.squadmap.common.excetpion.ErrorStatusCodeAndMessage;
+import com.squadmap.core.group.domain.GroupMember;
+import com.squadmap.core.group.domain.PermissionLevel;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.*;
+
+
+class GroupMemberTest {
+
+    private GroupMember host;
+    private GroupMember maintain;
+    private GroupMember read;
+
+    @BeforeEach
+    void setUp() {
+        host = GroupMember.of(1L, 1L, "HOST");
+        maintain = GroupMember.of(1L, 2L, "MAINTAIN");
+        read = GroupMember.of(1L, 3L, "READ");
+    }
+
+    @Test
+    void updatePermissionLevel_success_maintain_to_read_and_read_to_maintain() {
+        maintain.updatePermissionLevel("READ");
+        read.updatePermissionLevel("MAINTAIN");
+
+        assertThat(maintain.getPermissionLevel().equals(PermissionLevel.READ));
+        assertThat(maintain.getPermissionLevel().equals(PermissionLevel.MAINTAIN));
+    }
+    @Test
+    void updatePermissionLevel_fail_host_to_other_level() {
+
+        assertThatThrownBy(() -> host.updatePermissionLevel("MAINTAIN"))
+                .isInstanceOf(ClientException.class)
+                .hasMessage(ErrorStatusCodeAndMessage.HOST_IMMUTABLE.getMessage());
+
+        assertThatThrownBy(() -> host.updatePermissionLevel("READ"))
+                .isInstanceOf(ClientException.class)
+                .hasMessage(ErrorStatusCodeAndMessage.HOST_IMMUTABLE.getMessage());
+    }
+
+    @Test
+    void updatePermissionLevel_fail_other_level_to_host() {
+
+        assertThatThrownBy(() -> maintain.updatePermissionLevel("HOST"))
+                .isInstanceOf(ClientException.class)
+                .hasMessage(ErrorStatusCodeAndMessage.UNIQUE_HOST.getMessage());
+
+        assertThatThrownBy(() -> read.updatePermissionLevel("HOST"))
+                .isInstanceOf(ClientException.class)
+                .hasMessage(ErrorStatusCodeAndMessage.UNIQUE_HOST.getMessage());
+    }
+
+    @Test
+    void hasRequiredPermission_host() {
+
+        assertThat(host.hasRequiredPermission(PermissionLevel.READ)).isTrue();
+        assertThat(host.hasRequiredPermission(PermissionLevel.MAINTAIN)).isTrue();
+        assertThat(host.hasRequiredPermission(PermissionLevel.HOST)).isTrue();
+    }
+
+    @Test
+    void hasRequiredPermission_maintain() {
+
+        assertThat(maintain.hasRequiredPermission(PermissionLevel.READ)).isTrue();
+        assertThat(maintain.hasRequiredPermission(PermissionLevel.MAINTAIN)).isTrue();
+        assertThat(maintain.hasRequiredPermission(PermissionLevel.HOST)).isFalse();
+    }
+
+    @Test
+    void hasRequiredPermission_read() {
+
+        assertThat(read.hasRequiredPermission(PermissionLevel.READ)).isTrue();
+        assertThat(read.hasRequiredPermission(PermissionLevel.MAINTAIN)).isFalse();
+        assertThat(read.hasRequiredPermission(PermissionLevel.HOST)).isFalse();
+    }
+}

--- a/BE/src/test/java/com/squadmap/group/integretion/GroupServiceTest.java
+++ b/BE/src/test/java/com/squadmap/group/integretion/GroupServiceTest.java
@@ -137,4 +137,18 @@ class GroupServiceTest {
                 .hasMessage(ErrorStatusCodeAndMessage.HOST_IMMUTABLE.getMessage());
 
     }
+
+    @Test
+    @DisplayName("지도의 주인이 자신의 권한을 수정할 수 없다.")
+    void updateTest_fail_host_to_other_level() {
+        Long loginId = 1L;
+        Long mapId = 1L;
+        Long memberId = 1L;
+
+        assertThat(groupMemberRepository.findByMapIdAndMemberId(mapId, memberId)).isPresent();
+        assertThatThrownBy(() -> groupService.changeGroupMemberLevel(loginId, mapId, memberId, "MAINTAIN"))
+                .isInstanceOf(ClientException.class)
+                .hasMessage(ErrorStatusCodeAndMessage.HOST_IMMUTABLE.getMessage());
+
+    }
 }

--- a/BE/src/test/java/com/squadmap/map/domain/MapTest.java
+++ b/BE/src/test/java/com/squadmap/map/domain/MapTest.java
@@ -27,12 +27,4 @@ class MapTest {
         assertThat(map.isFullDisclosure()).isTrue();
     }
 
-    @Test
-    void randomChar() {
-        Random random = new Random();
-        for (int j = 0; j <100; j++) {
-            char i = (char) (random.nextInt(26) + 97);
-            System.out.println(i);
-        }
-    }
 }

--- a/BE/src/test/java/com/squadmap/map/integration/MapServiceTest.java
+++ b/BE/src/test/java/com/squadmap/map/integration/MapServiceTest.java
@@ -188,13 +188,14 @@ class MapServiceTest  {
     @DisplayName("유저 아이디로 지도를 검색하면, 그 유저가 속해있는 그룹 지도를 반환한다.")
     void searchGroupMapListTest() {
         //given
-        Long memberId = 1L;
+        Long memberId = 4L;
 
         //when
         MapsResponse mapsResponse = mapService.searchGroup(memberId, Optional.empty());
 
+        assertThat(mapsResponse.getContent().get(0).getId()).isEqualTo(2);
         //then
-        assertThat(mapsResponse.getMapCount()).isEqualTo(2);
+        assertThat(mapsResponse.getMapCount()).isEqualTo(1);
     }
 
 


### PR DESCRIPTION
## PR 내용

#172 

### 1. HOST 권한 수정 불가 로직 추가
- 기존 삭제에만 불가하도록 처리했던 로직에서 수정 또한 못하도록 로직 추가

### 2. 그룹 지도 조회 API 잘못된 정보 응답 오류 수정
- GroupMember의 id가 아닌 mapId의 리스트를 응답하도록 수정


### TODO

- logging 작업, logback 설정을 통해서 log 파일 수집
